### PR TITLE
Make jekyll-serve faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 *.DS_Store
 *.swp
 Gemfile.lock
+vendor/

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ jekyll serve
 Or run via Docker:
 
 ```sh
-export JEKYLL_VERSION=3.8
-docker run --rm \
-  -p 4000:4000 \
-  --volume="$PWD:/srv/jekyll" \
-  -it jekyll/jekyll:$JEKYLL_VERSION \
-  jekyll serve
+# full generation
+./docker-serve.sh
+
+# incremental generation
+./docker-serve.sh --incremental
 ```
 
 ## Generators

--- a/docker-serve.sh
+++ b/docker-serve.sh
@@ -4,8 +4,10 @@
 # https://github.com/envygeeks/jekyll-docker
 #
 export JEKYLL_VERSION=3.8
-docker run --rm \
+docker run \
+  --rm \
   -p 4000:4000 \
-  --volume="${PWD}:/srv/jekyll" \
-  -it jekyll/jekyll:$JEKYLL_VERSION \
-  jekyll serve
+  --volume "${PWD}:/srv/jekyll" \
+  --volume "${PWD}/vendor/bundle:/usr/local/bundle" \
+  jekyll/jekyll:$JEKYLL_VERSION \
+  jekyll serve $@

--- a/docker-serve.sh
+++ b/docker-serve.sh
@@ -4,10 +4,9 @@
 # https://github.com/envygeeks/jekyll-docker
 #
 export JEKYLL_VERSION=3.8
-docker run \
-  --rm \
+docker run --rm \
   -p 4000:4000 \
-  --volume "${PWD}:/srv/jekyll" \
-  --volume "${PWD}/vendor/bundle:/usr/local/bundle" \
-  jekyll/jekyll:$JEKYLL_VERSION \
+  --volume="${PWD}:/srv/jekyll" \
+  --volume="${PWD}/vendor/bundle:/usr/local/bundle" \
+  -it jekyll/jekyll:$JEKYLL_VERSION \
   jekyll serve $@


### PR DESCRIPTION
Currently serving Jekyll in localhost in done using Docker image `jekyll/jekyll`. The initial goal was to isolate the eventual Ruby problems and save times for writing actual articles. However, there are two main problems after introducing this concept:

1. Installing all the bundles are very slow (perhaps 5 minutes). And actually, there are only 3 plugins required by the site: jekyll-feed, jekyll-redirect-from, jekyll-sitemap 🤷‍♂️ 
2. Regeneration is very slow (about 30 seconds) as well because the incremental mode is disabled.

This PR addresses these two problems. The 1st item is handled by introducing the caching mechanism (https://github.com/envygeeks/jekyll-docker#caching):

> Caching
> 
> You can enable caching in Jekyll Docker by using a docker `--volume` that points to `/usr/local/bundle` inside of the image. This is ideal for users who run builds on CI's and wish them to be fast.

Therefore, all downloaded bundles are saved locally and does not require re-installation. File `.gitignore` needs to be adjusted so that this directory is ignored and not committed to Git.

The 2nd item is handled by supporting additional options for `docker-serve.sh` using `$@` to pass input arguments of the script to Docker command. Therefore, if incremental mode is required, we can just add the option to the script:

```sh
# full generation
./docker-serve.sh

# incremental generation
./docker-serve.sh --incremental
```