### PR TITLE
Ensure all images have the same size (width and height)

### DIFF
--- a/_includes/article-list.html
+++ b/_includes/article-list.html
@@ -113,7 +113,11 @@
           <div class="card card--flat">
             {%- if _article.cover -%}
               <div class="card__image">
-                <img class="image" src="{{ _article_cover }}" />
+                {%- if include.cover_type == 'background' -%}
+                  <div class="image card__background_image card__background_image_sm" style="background-image: url('{{ _article_cover }}')"></div>
+                {%- else -%}
+                  <img class="image" src="{{ _article_cover }}" />
+                {%- endif -%}
                 <div class="overlay overlay--bottom">
                   <header>
                     <a href="{{ _article_url }}"><h2 class="card__header">{{ _article.title }}</h2></a>
@@ -128,7 +132,13 @@
         <div class="cell cell--12 cell--md-6 cell--lg-4">
           <div class="card card--flat">
             {%- if _article.cover -%}
-              <div class="card__image"><img src="{{ _article_cover }}" /></div>
+              <div class="card__image">
+                {%- if include.cover_type == 'background' -%}
+                  <div class="card__background_image card__background_image_md" style="background-image: url('{{ _article_cover }}')"></div>
+                {%- else -%}
+                  <img src="{{ _article_cover }}" />
+                {%- endif -%}
+              </div>
             {%- endif -%}
               <div class="card__content">
                 <header>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -7,6 +7,6 @@ layout: page
 <div class="layout--articles">
   <section class="my-5">
     {% assign _articles = site.categories[page.category] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' -%}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
   </section>
 </div>

--- a/_sass/common/components/_card.scss
+++ b/_sass/common/components/_card.scss
@@ -37,6 +37,21 @@
     height: auto;
     border-radius: inherit;
   }
+  & > .card__background_image {
+    display: block;
+    width: 100%;
+    height: 10rem;
+    border-radius: inherit;
+
+    background-size: cover;
+    background-position: center;
+  }
+  & > .card__background_image_sm {
+    height: map-get($image, width-sm);
+  }
+  & > .card__background_image_md {
+    height: map-get($image, width);
+  }
   & > .overlay {
     position: absolute;
     width: 100%;
@@ -93,6 +108,9 @@
   @include box-shadow(0);
   .card__image {
     & > img {
+      border-radius: map-get($base, border-radius);
+    }
+    & > .card__background_image {
       border-radius: map-get($base, border-radius);
     }
   }

--- a/about.md
+++ b/about.md
@@ -19,6 +19,6 @@ solution.
 <div class="layout--articles">
   <section class="my-5">
     <header><h2 id="categories">Categories</h2></header>
-    {%- include article-list.html articles=site.displayed_categories type='grid' size='sm' -%}
+    {%- include article-list.html articles=site.displayed_categories type='grid' size='sm' cover_type='background' -%}
   </section>
 </div>

--- a/categories.md
+++ b/categories.md
@@ -6,6 +6,6 @@ permalink: /categories/
 
 <div class="layout--articles">
   <section class="my-5">
-    {%- include article-list.html articles=site.displayed_categories type='grid' size='md' -%}
+    {%- include article-list.html articles=site.displayed_categories type='grid' size='md' cover_type='background' -%}
   </section>
 </div>


### PR DESCRIPTION
## Problem

Currently the images shown in the "categories" page (https://mincong.io/categories/) or in the categories section of the "about" page (https://mincong.io/about/) do not have the same size.

![Screenshot 2021-02-14 at 09 58 45](https://user-images.githubusercontent.com/10179217/107872537-43bf3700-6eab-11eb-9642-789cfdb3829a.png)

![Screenshot 2021-02-14 at 09 52 30](https://user-images.githubusercontent.com/10179217/107872405-7ae11880-6eaa-11eb-987a-76f8806296b5.png)

 This is because the current styling system of Jekyll TeXt Theme do not support this use-case. It uses the card system (https://tianqi.name/jekyll-TeXt-theme/docs/en/card), where images are considered as a read element inside the card. To have the same size (width and height), we need to consider image as background of the card, so that the image will adapt to the card and not the other way around.