### PR TITLE
Better control comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Property | Value | Description
 :--- | :--- | :---
 `image` | Image URL | Related path to image resource, such as `/assets/my-image.jpg`. Jekyll will complete it as an absolute path. Used by [Jekyll Feed](https://github.com/jekyll/jekyll-feed#optional-front-matter) plugin and my own structured data generation.
 `series` | A meaningful name for the series. | The value will be `slugify` for generating the URL. For example, giving value "Maven Plugins" will generate `maven-plugins` for the URL.
+`comments` | Whether the comments section will be enabled. Default to true.
 
 ## Assets
 

--- a/_displayed_categories/build.md
+++ b/_displayed_categories/build.md
@@ -5,4 +5,5 @@ category:          build
 cover:             /assets/bg-c-dustin-91AQt9p4Mo8-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/elasticsearch.md
+++ b/_displayed_categories/elasticsearch.md
@@ -5,4 +5,5 @@ category:          elasticsearch
 cover:             /assets/bg-cristian-escobar-abkEAOjnY0s-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/git.md
+++ b/_displayed_categories/git.md
@@ -5,4 +5,5 @@ category:          git
 cover:             /assets/bg-josh-calabrese-zcYRw547Dps-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/java-concurrency.md
+++ b/_displayed_categories/java-concurrency.md
@@ -5,4 +5,5 @@ category:          java-concurrency
 cover:             /assets/bg-powerboat-2784250_1280.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/java-core.md
+++ b/_displayed_categories/java-core.md
@@ -5,4 +5,5 @@ category:          java-core
 cover:             /assets/bg-willian-justen-de-vasconcellos-3fX0FvA-2us-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/java-rest.md
+++ b/_displayed_categories/java-rest.md
@@ -5,4 +5,5 @@ category:          java-rest
 cover:             /assets/bg-park-troopers-RAtKWVlfdf4-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/java-serialization.md
+++ b/_displayed_categories/java-serialization.md
@@ -5,4 +5,5 @@ category:          java-serialization
 cover:             /assets/bg-lance-grandahl-hF6TtT-xz80-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/java-testing.md
+++ b/_displayed_categories/java-testing.md
@@ -5,4 +5,5 @@ category:          java-testing
 cover:             /assets/bg-board-2450236_1280.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/python.md
+++ b/_displayed_categories/python.md
@@ -5,4 +5,5 @@ category:          python
 cover:             /assets/bg-snake-37585_1280.png
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/reliability.md
+++ b/_displayed_categories/reliability.md
@@ -5,4 +5,5 @@ category:          reliability
 cover:             /assets/bg-sarah-kilian-52jRtc2S_VE-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_displayed_categories/review.md
+++ b/_displayed_categories/review.md
@@ -5,4 +5,5 @@ category:          review
 cover:             /assets/bg-markus-winkler-afW1hht0NSs-unsplash.jpg
 sidebar:
   nav:             categories
+comments:          false
 ---

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -25,7 +25,7 @@ layout: base
 {%- include snippets/assign.html
   target = site.data.variables.default.page.comment
   source0=layout.comment source1=page.comment -%}
-{%- assign _comment = __return -%}
+{%- assign _comment = page.comments -%}
 
 
 {%- assign _article_header_excerpt_truncate = include.excerpt_truncate | default: 200 -%}

--- a/newcategory.sh
+++ b/newcategory.sh
@@ -36,6 +36,7 @@ title:             ${title}
 category:          ${category}
 sidebar:
   nav:             categories
+comments:          false
 ---
 EOF
 


### PR DESCRIPTION
Current comments are enabled for category-pages. This PR disables it. More precisely, this PR allows users to control the comment-section enabling using variable `post.comments` (boolean). Comments are enabled by default, unless it is disabled explicitly.