### PR TITLE
Introduce new post variable: subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+- 2021-04-13 Introduce new post variable `subtitle` to better fit the post
+  (article) web page. (#24)
+- 2021-03-08 Improve SEO (#20, #22, #23)
+- 2021-02-15 Disable comments for category pages (#17)
+- 2021-02-14 Ensure that all the images have the same size (#16)
+- 2021-02-14 Use new Jekyll theme: TeXt (#14)

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -148,7 +148,9 @@ layout: base
                   {%- endif -%}
                     {%- include article-info.html article=page semantic=false -%}
                     {%- include article-header.html article=page semantic=false -%}
-                    {%- if page.excerpt -%}
+                    {%- if page.subtitle -%}
+                      <p class="overlay__excerpt">{{ page.subtitle | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
+                    {%- elsif page.excerpt -%}
                       <p class="overlay__excerpt">{{ page.excerpt | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
                     {%- endif -%}
                     {%- if page.article_header.actions -%}

--- a/_posts/2021-04-09-junit-5-dynamic-tests.md
+++ b/_posts/2021-04-09-junit-5-dynamic-tests.md
@@ -1,6 +1,9 @@
 ---
 layout:              post
 title:               "JUnit 5: Dynamic Tests with TestFactory"
+subtitle:            >
+    A new programming model introduced in JUnit 5.
+
 date:                2021-04-09 08:54:59 +0800
 categories:          [java-testing]
 tags:                [java, junit, junit5, testing]
@@ -9,6 +12,7 @@ excerpt:             >
     How to write dynamic tests using @TestFactory in JUnit 5? This article
     explains the syntax, different return types, the test lifecycle, and
     potential use-cases.
+
 image:               /assets/bg-mike-kenneally-tNALoIZhqVM-unsplash.jpg
 cover:               /assets/bg-mike-kenneally-tNALoIZhqVM-unsplash.jpg
 article_header:

--- a/_posts/2021-04-10-disk-watermarks-in-elasticsearch.md
+++ b/_posts/2021-04-10-disk-watermarks-in-elasticsearch.md
@@ -1,6 +1,9 @@
 ---
 layout:              post
 title:               Disk Watermarks In Elasticsearch
+subtitle:            >
+    Three disk watermarks: low, high, and flood-stage in Elasticsearch.
+
 date:                2021-04-10 07:00:00 +0800
 categories:          [elasticsearch]
 tags:                [elasticsearch]

--- a/_posts/2021-04-11-elasticsearch-generate-configuration-with-python-jinja2.md
+++ b/_posts/2021-04-11-elasticsearch-generate-configuration-with-python-jinja2.md
@@ -1,6 +1,9 @@
 ---
 layout:              post
 title:               "Elasticsearch: Generate Configuration With Python Jinja 2"
+subtitle:            >
+     Making your Elasticsearch configuration safe and consistent.
+
 date:                2021-04-11 08:31:10 +0800
 categories:          [elasticsearch, python]
 tags:                [elasticsearch, python, jinja]
@@ -9,6 +12,7 @@ excerpt:             >
     This article explains how to generate the configuration for Elasticsearch using
     Python templating engine Jinja 2 by going through a basic use-case. It also
     explains features about Jinja2, testing, and more.
+
 image:               /assets/bg-heiman-ip-iFk8n8ntVDU-unsplash.jpg
 cover:               /assets/bg-heiman-ip-iFk8n8ntVDU-unsplash.jpg
 article_header:

--- a/_posts/2021-04-12-dvf-aggregations.md
+++ b/_posts/2021-04-12-dvf-aggregations.md
@@ -1,6 +1,10 @@
 ---
 layout:              post
 title:               "DVF: Aggregations"
+subtitle:            >
+    Metric aggregations, bucket aggregations, scripted aggregation, and
+    sub-aggregations in Elasticsearch.
+
 date:                2021-04-12 07:34:30 +0800
 categories:          [elasticsearch]
 tags:                [elasticsearch, java]

--- a/_sass/components/_article-header.scss
+++ b/_sass/components/_article-header.scss
@@ -37,7 +37,7 @@
     @include media-breakpoint-down(md) {
       font-size: map-get($base, font-size-h3-sm);
     }
-    font-weight: map-get($base, font-weight-bold);
+    font-weight: map-get($base, font-weight);
   }
 
   .article__header {


### PR DESCRIPTION
## Motivation

Currently, the Jekyll Text Theme uses the `excerpt` for each article, displayed under the title of the article. However, the text is too long and too big to have a comfortable reading experience. Nevertheless, we cannot completely delete this block because it has a positive impact in the design — without it, the title become too small for the background image.

That's why this PR introduces a new post variable `subtitle`. `subtitle` is designed to be used as the subtitle of the blog post when user opens the web page of the article. However, it does not replace the `except` which is used in the article listing page (scroll) and used for post sharing in social network.

## Corner Cases

If the `subtitle` does not exist, we still want to display some text as before. So we fallback to the `except` in this case.

## Preview

Here are the previews of the changes (before/after/rejected):

<img width="367" alt="diff-1v" src="https://user-images.githubusercontent.com/10179217/114507396-a5124500-9c65-11eb-85aa-8f7aa88430d9.png">

<img width="367" alt="diff-2v" src="https://user-images.githubusercontent.com/10179217/114507427-b0fe0700-9c65-11eb-9ff0-0b4ff42370c7.png">
