### PR TITLE
Add image attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2021-04-13 Add missing image attribute for backgound image, e.g. "Photo by Tom
+  on Unplash" (#26)
 - 2021-04-13 Introduce new post variable `subtitle` to better fit the post
   (article) web page. (#24, #25)
 - 2021-03-08 Improve SEO (#20, #22, #23)

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -1,0 +1,96 @@
+{%- assign _author = site.data.authors[include.article.author] | default: site.author -%}
+
+{%- if include.html != false -%}
+
+  {%- include snippets/assign.html
+    target=site.data.variables.default.page.show_date
+    source0=layout.show_date source1=include.article.show_date -%}
+  {%- assign _show_date = __return -%}
+  {%- if _show_date and include.article.date -%}
+    {%- assign _show_date = true -%}
+  {%- else -%}
+    {%- assign _show_date = false -%}
+  {%- endif -%}
+
+  {%- include snippets/assign.html
+    target=site.data.variables.default.page.show_tags
+    source0=layout.show_tags source1=include.article.show_tags -%}
+  {%- assign _show_tags = __return -%}
+  {%- if _show_tags and include.article.tags[0] -%}
+    {%- assign _show_tags = true -%}
+  {%- else -%}
+    {%- assign _show_tags = false -%}
+  {%- endif -%}
+
+  {%- assign _show_author = include.article.author -%}
+
+  {%- include snippets/assign.html target=site.data.variables.default.page.pageview
+    source0=layout.pageview source1=page.pageview -%}
+  {%- assign _pageview = __return -%}
+  {%- if _pageview or include.show_pageview -%}
+    {%- assign _pageview = true -%}
+  {%- else -%}
+    {%- assign _pageview = false -%}
+  {%- endif -%}
+
+  {%- assign _paths_archive = site.paths.archive | default: site.data.variables.default.paths.archive -%}
+
+  {%- if _show_tags or _show_author or _show_date or _pageview -%}
+    <div class="article__info clearfix">
+      {%- if _show_tags -%}
+
+        <ul class="left-col menu">
+          {%- assign _tag_path = _paths_archive | append: '?tag=' -%}
+          {%- include snippets/prepend-baseurl.html path=_tag_path -%}
+
+          {%- for _tag in include.article.tags -%}
+            {%- assign _tag_path = __return -%}
+            {%- assign _tag_encode = _tag | strip | url_encode } -%}
+            <li>
+              <a class="button button--secondary button--pill button--sm"
+                href="{{ _tag_path | append: _tag_encode | replace: '//', '/' }}">{{ _tag }}</a>
+            </li>
+          {%- endfor -%}
+        </ul>
+      {%- endif -%}
+
+      {%- if _show_author or _show_date or _pageview -%}
+        <ul class="right-col menu">
+          {%- if _show_author  -%}
+            <li><i class="fas fa-user"></i> <span>{{ _author.name }}</span></li>
+          {%- endif -%}
+
+          {%- if _show_date -%}
+            <li>
+              {%- include snippets/get-locale-string.html key='ARTICLE_DATE_FORMAT' -%}
+              <i class="far fa-calendar-alt"></i> <span>{{ include.article.date | date: __return }}</span>
+            </li>
+          {%- endif -%}
+
+          {%- if _pageview -%}
+            {%- if site.pageview.provider -%}
+              {%- include snippets/get-locale-string.html key='VIEWS' -%}
+              {%- assign _locale_views = __return -%}
+              <li><i class="far fa-eye"></i> <span class="js-pageview" data-page-key="{{ include.article.key }}">0</span> {{ _locale_views }}</li>
+            {%- endif -%}
+          {%- endif -%}
+        </ul>
+      {%- endif -%}
+
+    </div>
+  {%- endif -%}
+{%- endif -%}
+
+
+{%- if include.semantic != false -%}
+  {%- if _author -%}
+    <meta itemprop="author" content="{{ _author.name }}"/>
+  {%- endif -%}
+  {%- if include.article.date -%}
+    <meta itemprop="datePublished" content="{{ include.article.date | date_to_xmlschema }}">
+  {%- endif -%}
+  {%- if include.article.tags[0] -%}
+    {%- assign _keywords = include.article.tags | join: ',' %}
+    <meta itemprop="keywords" content="{{ _keywords }}">
+  {%- endif -%}
+{%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -3,11 +3,11 @@
     <li>
       <i class="fas fa-camera"></i>
       Photo by
-      <a href="{{ site.data.images[page.image].url }}">
+      <a href="{{ site.data.images[page.image].url }}" target="_blank">
         {{ site.data.images[page.image].author }}
       </a>
       on
-      <a href="{{ site.data.images[page.image].license_url }}">
+      <a href="{{ site.data.images[page.image].license_url }}" target="_blank">
         {{ site.data.images[page.image].license | remove: "License" }}
       </a>
     </li>

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -1,4 +1,3 @@
-{%- if include.html != false -%}
     <div class="article__info clearfix">
         <ul class="left-col menu">
           <li>
@@ -14,4 +13,3 @@
           </li>
         </ul>
     </div>
-{%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -1,40 +1,4 @@
-{%- assign _author = site.data.authors[include.article.author] | default: site.author -%}
-
 {%- if include.html != false -%}
-
-  {%- include snippets/assign.html
-    target=site.data.variables.default.page.show_date
-    source0=layout.show_date source1=include.article.show_date -%}
-  {%- assign _show_date = __return -%}
-  {%- if _show_date and include.article.date -%}
-    {%- assign _show_date = true -%}
-  {%- else -%}
-    {%- assign _show_date = false -%}
-  {%- endif -%}
-
-  {%- include snippets/assign.html
-    target=site.data.variables.default.page.show_tags
-    source0=layout.show_tags source1=include.article.show_tags -%}
-  {%- assign _show_tags = __return -%}
-  {%- if _show_tags and include.article.tags[0] -%}
-    {%- assign _show_tags = true -%}
-  {%- else -%}
-    {%- assign _show_tags = false -%}
-  {%- endif -%}
-
-  {%- assign _show_author = include.article.author -%}
-
-  {%- include snippets/assign.html target=site.data.variables.default.page.pageview
-    source0=layout.pageview source1=page.pageview -%}
-  {%- assign _pageview = __return -%}
-  {%- if _pageview or include.show_pageview -%}
-    {%- assign _pageview = true -%}
-  {%- else -%}
-    {%- assign _pageview = false -%}
-  {%- endif -%}
-
-  {%- assign _paths_archive = site.paths.archive | default: site.data.variables.default.paths.archive -%}
-
     <div class="article__info clearfix">
         <ul class="left-col menu">
           <li>

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -40,17 +40,12 @@
       {%- if _show_tags -%}
 
         <ul class="left-col menu">
-          {%- assign _tag_path = _paths_archive | append: '?tag=' -%}
-          {%- include snippets/prepend-baseurl.html path=_tag_path -%}
-
-          {%- for _tag in include.article.tags -%}
-            {%- assign _tag_path = __return -%}
-            {%- assign _tag_encode = _tag | strip | url_encode } -%}
-            <li>
-              <a class="button button--secondary button--pill button--sm"
-                href="{{ _tag_path | append: _tag_encode | replace: '//', '/' }}">{{ _tag }}</a>
-            </li>
-          {%- endfor -%}
+          <li>
+            Photo by
+            <a href="https://unsplash.com/@todo">Andre Tan</a>
+            on
+            <a href="https://unsplash.com/">Unsplash</a>
+          </li>
         </ul>
       {%- endif -%}
 

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -48,30 +48,6 @@
           </li>
         </ul>
       {%- endif -%}
-
-      {%- if _show_author or _show_date or _pageview -%}
-        <ul class="right-col menu">
-          {%- if _show_author  -%}
-            <li><i class="fas fa-user"></i> <span>{{ _author.name }}</span></li>
-          {%- endif -%}
-
-          {%- if _show_date -%}
-            <li>
-              {%- include snippets/get-locale-string.html key='ARTICLE_DATE_FORMAT' -%}
-              <i class="far fa-calendar-alt"></i> <span>{{ include.article.date | date: __return }}</span>
-            </li>
-          {%- endif -%}
-
-          {%- if _pageview -%}
-            {%- if site.pageview.provider -%}
-              {%- include snippets/get-locale-string.html key='VIEWS' -%}
-              {%- assign _locale_views = __return -%}
-              <li><i class="far fa-eye"></i> <span class="js-pageview" data-page-key="{{ include.article.key }}">0</span> {{ _locale_views }}</li>
-            {%- endif -%}
-          {%- endif -%}
-        </ul>
-      {%- endif -%}
-
     </div>
   {%- endif -%}
 {%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -51,17 +51,3 @@
         </ul>
     </div>
 {%- endif -%}
-
-
-{%- if include.semantic != false -%}
-  {%- if _author -%}
-    <meta itemprop="author" content="{{ _author.name }}"/>
-  {%- endif -%}
-  {%- if include.article.date -%}
-    <meta itemprop="datePublished" content="{{ include.article.date | date_to_xmlschema }}">
-  {%- endif -%}
-  {%- if include.article.tags[0] -%}
-    {%- assign _keywords = include.article.tags | join: ',' %}
-    <meta itemprop="keywords" content="{{ _keywords }}">
-  {%- endif -%}
-{%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -41,6 +41,7 @@
 
         <ul class="left-col menu">
           <li>
+            <i class="fas fa-camera"></i>
             Photo by
             <a href="{{ site.data.images[page.image].url }}">
               {{ site.data.images[page.image].author }}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -42,9 +42,13 @@
         <ul class="left-col menu">
           <li>
             Photo by
-            <a href="{{ site.data.images[page.image].url }}">{{ site.data.images[page.image].author }}</a>
+            <a href="{{ site.data.images[page.image].url }}">
+              {{ site.data.images[page.image].author }}
+            </a>
             on
-            <a href="{{ site.data.images[page.image].license_url }}">{{ site.data.images[page.image].license }}</a>
+            <a href="{{ site.data.images[page.image].license_url }}">
+              {{ site.data.images[page.image].license | remove: "License" }}
+            </a>
           </li>
         </ul>
       {%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -35,10 +35,7 @@
 
   {%- assign _paths_archive = site.paths.archive | default: site.data.variables.default.paths.archive -%}
 
-  {%- if _show_tags or _show_author or _show_date or _pageview -%}
     <div class="article__info clearfix">
-      {%- if _show_tags -%}
-
         <ul class="left-col menu">
           <li>
             <i class="fas fa-camera"></i>
@@ -52,9 +49,7 @@
             </a>
           </li>
         </ul>
-      {%- endif -%}
     </div>
-  {%- endif -%}
 {%- endif -%}
 
 

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -42,9 +42,9 @@
         <ul class="left-col menu">
           <li>
             Photo by
-            <a href="https://unsplash.com/@todo">Andre Tan</a>
+            <a href="{{ site.data.images[page.image].url }}">{{ site.data.images[page.image].author }}</a>
             on
-            <a href="https://unsplash.com/">Unsplash</a>
+            <a href="{{ site.data.images[page.image].license_url }}">{{ site.data.images[page.image].license }}</a>
           </li>
         </ul>
       {%- endif -%}

--- a/_includes/article-info-footer.html
+++ b/_includes/article-info-footer.html
@@ -1,15 +1,15 @@
-    <div class="article__info clearfix">
-        <ul class="left-col menu">
-          <li>
-            <i class="fas fa-camera"></i>
-            Photo by
-            <a href="{{ site.data.images[page.image].url }}">
-              {{ site.data.images[page.image].author }}
-            </a>
-            on
-            <a href="{{ site.data.images[page.image].license_url }}">
-              {{ site.data.images[page.image].license | remove: "License" }}
-            </a>
-          </li>
-        </ul>
-    </div>
+<div class="article__info clearfix">
+  <ul class="left-col menu">
+    <li>
+      <i class="fas fa-camera"></i>
+      Photo by
+      <a href="{{ site.data.images[page.image].url }}">
+        {{ site.data.images[page.image].author }}
+      </a>
+      on
+      <a href="{{ site.data.images[page.image].license_url }}">
+        {{ site.data.images[page.image].license | remove: "License" }}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -149,9 +149,13 @@ layout: base
                     {%- include article-info.html article=page semantic=false -%}
                     {%- include article-header.html article=page semantic=false -%}
                     {%- if page.subtitle -%}
-                      <p class="overlay__excerpt">{{ page.subtitle | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
+                      <div class="article__header">
+                        <p class="overlay__excerpt">{{ page.subtitle | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
+                      </div>
                     {%- elsif page.excerpt -%}
-                      <p class="overlay__excerpt">{{ page.excerpt | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
+                      <div class="article__header">
+                        <p class="overlay__excerpt">{{ page.excerpt | strip_html | strip_newlines | strip | truncate: _article_header_excerpt_truncate }}</p>
+                      </div>
                     {%- endif -%}
                     {%- if page.article_header.actions -%}
                       <ul class="menu">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -163,6 +163,7 @@ layout: base
                         {%- endfor -%}
                       </ul>
                     {%- endif -%}
+                    {%- include article-info-footer.html article=page semantic=false -%}
                   {%- if _full_width == false -%}
                     </div>
                   {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -167,7 +167,7 @@ layout: base
                         {%- endfor -%}
                       </ul>
                     {%- endif -%}
-                    {%- include article-info-footer.html article=page -%}
+                    {%- include article-info-footer.html -%}
                   {%- if _full_width == false -%}
                     </div>
                   {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -167,7 +167,7 @@ layout: base
                         {%- endfor -%}
                       </ul>
                     {%- endif -%}
-                    {%- include article-info-footer.html article=page semantic=false -%}
+                    {%- include article-info-footer.html article=page -%}
                   {%- if _full_width == false -%}
                     </div>
                   {%- endif -%}


### PR DESCRIPTION
## Motivation

Add image attribute in all articles, a way to say thanks for the authors that provide the image for free. This is the feature that I missed the most from the Jekyll Theme TeXt.

## Preview

<img width="1280" alt="Screenshot 2021-04-13 at 16 59 13" src="https://user-images.githubusercontent.com/10179217/114529801-e7934c00-9c7c-11eb-9bb3-6353125a6f6e.png">

<img width="361" alt="Screenshot 2021-04-13 at 17 00 05" src="https://user-images.githubusercontent.com/10179217/114529844-f24de100-9c7c-11eb-9813-16ffae423336.png">
