### PR TITLE
Simplify deploy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,5 @@ jobs:
     - name: Deploy GitHub Pages
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
-        ACCESS_TOKEN: ${{ secrets.GIT_PAGE_DEPLOY }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: _site # The folder the action should deploy.
-        REPOSITORY_NAME: mincong-h/mincong-h.github.io
+        branch: gh-pages
+        folder: _site


### PR DESCRIPTION
By default, GitHub action has a repository-scope token called `GITHUB_TOKEN` and the GitHub action deploys to the same repository (`mincong-h/mincong-h.github.io`). So there is no need to use a personal access token (PAT) and no need to declare the repository name.