### PR TITLE
Add Jekyll plugin for BlogSearch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Build Jekyll website
       run: |
          bundle exec jekyll build
+      env:
+        JIMI_USERNAME: "${{ secrets.JIMI_USERNAME }}"
+        JIMI_PASSWORD: "${{ secrets.JIMI_PASSWORD }}"
     - name: Deploy GitHub Pages
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -1,0 +1,3 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  Jekyll.logger.info "Updating blog posts to BlogSearch..."
+end

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -6,5 +6,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
         # Jekyll.logger.info post.data["date"].class
         Jekyll.logger.info post.data["date"].strftime("%FT%T%:z")
         Jekyll.logger.info post.data["title"].strip
+        Jekyll.logger.info site.url + post.url
+        Jekyll.logger.info "---"
     }
 end

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -1,3 +1,6 @@
 Jekyll::Hooks.register :site, :post_write do |site|
-  Jekyll.logger.info "Updating blog posts to BlogSearch..."
+    Jekyll.logger.info "Updating blog posts to BlogSearch..."
+    site.posts.docs.each { |post|
+        Jekyll.logger.info post.data['title']
+    }
 end

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -26,9 +26,12 @@ Jekyll::Hooks.register :site, :post_write do |site|
         http.use_ssl = true
 
         headers = {"Content-Type": "application/json"}
+        body = {"title" => title, "url" => url, "content" => content}.to_json
+        Jekyll.logger.info body
+
         request = Net::HTTP::Put.new(uri.request_uri, headers)
         request.basic_auth username, password
-        request.body = {"title" => title, "url" => url, "content" => content}.to_json,
+        request.body = body
 
         response = http.request(request)
 

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -1,6 +1,10 @@
 Jekyll::Hooks.register :site, :post_write do |site|
     Jekyll.logger.info "Updating blog posts to BlogSearch..."
+
+    # See more variables in https://jekyllrb.com/docs/variables/
     site.posts.docs.each { |post|
-        Jekyll.logger.info post.data['title']
+        # Jekyll.logger.info post.data["date"].class
+        Jekyll.logger.info post.data["date"].strftime("%FT%T%:z")
+        Jekyll.logger.info post.data["title"].strip
     }
 end

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -1,5 +1,16 @@
+require 'net/http'
+
 Jekyll::Hooks.register :site, :post_write do |site|
     Jekyll.logger.info "Updating blog posts to BlogSearch..."
+    Jekyll.logger.info ENV["JIMI_USERNAME"]
+    Jekyll.logger.info ENV["JIMI_PASSWORD"]
+
+    Jekyll.logger.info "Getting information from Jimi Data"
+    uri = URI('https://search.jimidata.info')
+    response = Net::HTTP.get_response(uri)
+    Jekyll.logger.info response.code
+    Jekyll.logger.info response.body
+    Jekyll.logger.info "==="
 
     # See more variables in https://jekyllrb.com/docs/variables/
     site.posts.docs.each { |post|

--- a/_plugins/hooks/site/post_write/blogsearch.rb
+++ b/_plugins/hooks/site/post_write/blogsearch.rb
@@ -6,7 +6,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
         # Jekyll.logger.info post.data["date"].class
         Jekyll.logger.info post.data["date"].strftime("%FT%T%:z")
         Jekyll.logger.info post.data["title"].strip
-        Jekyll.logger.info site.url + post.url
+        Jekyll.logger.info post.url
         Jekyll.logger.info "---"
     }
 end

--- a/docker-serve.sh
+++ b/docker-serve.sh
@@ -10,7 +10,10 @@
 export JEKYLL_VERSION=3.8
 docker run --rm \
   -p 4000:4000 \
-  --volume="${PWD}:/srv/jekyll" \
-  --volume="${PWD}/vendor/bundle:/usr/local/bundle" \
-  -it jekyll/jekyll:$JEKYLL_VERSION \
+  --env "JIMI_USERNAME=${JIMI_USERNAME}" \
+  --env "JIMI_PASSWORD=${JIMI_PASSWORD}" \
+  --name jekyll \
+  --volume "${PWD}:/srv/jekyll" \
+  --volume "${PWD}/vendor/bundle:/usr/local/bundle" \
+  -it "jekyll/jekyll:${JEKYLL_VERSION}" \
   jekyll serve $@


### PR DESCRIPTION
## Description

Currently, Jimi Search reads blog posts by parsing the blog feed (https://mincong.io/feed.xml). It works well for recent posts, but for older posts, it does not work as the feed does not include them. Also, parsing XML (feed) can be error-prone. A better idea is to use [Jekyll Plugin](https://jekyllrb.com/docs/plugins/your-first-plugin/) to access Jekyll's information and update the posts accordingly via RESTful APIs.

Running the command locally:

```
➜  mincong-h.github.io git:(plugins) ./docker-serve.sh --trace
```

## References

- https://jekyllrb.com/docs/plugins/your-first-plugin/
- https://jekyllrb.com/docs/plugins/hooks/
- https://www.mslinn.com/blog/2022/03/27/jekyll-plugin-background.html
- https://github.com/Ordina-JTech/Ordina-JTech.github.io/tree/source/_plugins/hooks/site/post_read
- https://apidock.com/ruby/Time/strftime
- https://github.com/mincong-h/mincong-h.github.io/pull/55
- https://ruby-doc.org/stdlib-2.7.1/libdoc/net/http/rdoc/Net/HTTP.html
- https://coderwall.com/p/c-mu-a/http-posts-in-ruby