### PR TITLE
Add action name for the search button

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
           <a href="{{ _site_root }}">{{ _site_title }}</a>
         </div>
         {%- if site.search.provider -%}
-          <button class="button button--secondary button--circle search-button js-search-toggle">
+          <button class="button button--secondary button--circle search-button js-search-toggle" data-dd-action-name="search">
             <i class="fas fa-search"></i>
           </button>
         {%- endif -%}


### PR DESCRIPTION
This PR adds an action name for the search button. Currently it takes the whole menu ("Categories Series Archive About") which is impossible to read. See doc ["Declaring a name for click actions | Datadog"](https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions/?tab=npm#declaring-a-name-for-click-actions)