### PR TITLE
Change home page layout

### DIFF
--- a/_includes/article-list.html
+++ b/_includes/article-list.html
@@ -12,6 +12,11 @@
 {%- if include.reverse -%}
   {%- assign _sorted_list = _sorted_list | reverse -%}
 {%- endif -%}
+{%- if include.limit -%}
+  {%- assign limit = include.limit -%}
+{%- else -%}
+  {%- assign limit = _sorted_list | size -%}
+{%- endif -%}
 
 {%- if include.type == 'item' -%}
 <div class="article-list items items--divided">
@@ -25,7 +30,7 @@
   {%- endif -%}
 {%- endif -%}
 
-  {%- for _article in _sorted_list -%}
+  {%- for _article in _sorted_list limit: limit -%}
 
     {%- include snippets/prepend-baseurl.html path=_article.url -%}
     {%- assign _article_url = __return -%}

--- a/_includes/article-list.html
+++ b/_includes/article-list.html
@@ -155,6 +155,9 @@
                 <p>
                   {{ _article.excerpt }}
                 </p>
+                {%- if include.with_date -%}
+                  <p>{{ _article.date | date_to_string }}</p>
+                {%- endif -%}
               </div>
           </div>
         </div>

--- a/_includes/article-list.html
+++ b/_includes/article-list.html
@@ -128,7 +128,7 @@
                 </div>
               </div>
             {%- endif -%}
-            </div>
+          </div>
         </div>
       {%- else -%}
 
@@ -147,6 +147,9 @@
                 <header>
                   <a href="{{ _article_url }}"><h2 class="card__header">{{ _article.title }}</h2></a>
                 </header>
+                <p>
+                  {{ _article.excerpt }}
+                </p>
               </div>
           </div>
         </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,44 +26,24 @@ titles:
 show_title: false
 ---
 
-<div class="article__content">
-  <h2>Java Core</h2>
-</div>
-  
-<div class="layout--articles">
-  <section class="my-5">
-    {% assign _articles = site.categories["java-core"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
-    <p>
-      <a href="/en/categories/java-core/">Read more...</a> ({{ site.categories["java-core"] | size }} articles)
-    </p>
-  </section>
-</div>
+{%- assign _highlighted_categories = 'temporal:Automation, elasticsearch:Elasticsearch, java-core:Java, java-testing:Testing, java-concurrency:Java Concurrency, java-rest:RESTful APIs, git:Git' | split: ', ' -%}
 
+{%- for _category in _highlighted_categories -%}
+  {%- assign _kv = _category | split: ':' -%}
+  {%- assign _category_id = _kv.first -%}
+  {%- assign _category_title = _kv.last -%}
 
-<div class="layout--articles">
   <div class="article__content">
-    <h2>Java Testing</h2>
+    <h2>{{ _category_title }}</h2>
   </div>
-  <section class="my-5">
-    {% assign _articles = site.categories["java-testing"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
-    <p>
-      <a href="/en/categories/java-testing/">Read more...</a> ({{ site.categories["java-testing"] | size }} articles)
-    </p>
-  </section>
-</div>
 
-<div class="article__content">
-  <h2>RESTful APIs</h2>
-</div>
-
-<div class="layout--articles">
-  <section class="my-5">
-    {% assign _articles = site.categories["java-rest"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
-    <p>
-      <a href="/en/categories/java-rest/">Read more...</a> ({{ site.categories["java-rest"] | size }} articles)
-    </p>
-  </section>
-</div>
+  <div class="layout--articles">
+    <section class="my-5">
+      {% assign _articles = site.categories[_category_id] %}
+      {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
+      <p>
+        <a href="/en/categories/{{ _category_id }}/">Read more...</a> ({{ site.categories[_category_id] | size }} articles)
+      </p>
+    </section>
+  </div>
+{%- endfor -%}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -34,9 +34,17 @@ articles:
   show_info: true
 ---
 
+<div class="layout--articles">
+  <section class="my-5">
+    {% assign _articles = site.categories[page.category] %}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+  </section>
+</div>
+
 <div class="layout--home">
   {%- include paginator.html paginate_pattern=page.paginate_pattern baseurl=page.baseurl -%}
 </div>
+
 <script>
   {%- include scripts/home.js -%}
 </script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: articles
 titles:
   # @start locale config
   en      : &EN       Home
@@ -24,33 +24,21 @@ titles:
   fr-LU   : *FR
   # @end locale config
 show_title: false
+articles:
+  data_source: paginator.posts
+  article_type: BlogPosting
+  show_cover: true
+  cover_size: lg
+  show_excerpt: true
+  show_readmore: true
+  show_info: true
 ---
 
-{%- assign _highlighted_categories = 'temporal:Automation, elasticsearch:Elasticsearch, java-core:Java, java-testing:Testing, java-concurrency:Java Concurrency, java-rest:RESTful APIs, git:Git' | split: ', ' -%}
+<div class="layout--home">
+  {%- include paginator.html paginate_pattern=page.paginate_pattern baseurl=page.baseurl -%}
+</div>
+<script>
+  {%- include scripts/home.js -%}
+</script>
 
-{%- for _category in _highlighted_categories -%}
-  {%- assign _kv = _category | split: ':' -%}
-  {%- assign _category_id = _kv.first -%}
-  {%- assign _category_title = _kv.last -%}
-
-  <div class="article__content">
-    <h2>{{ _category_title }}</h2>
-  </div>
-
-  <div class="layout--articles">
-    <section class="my-5">
-      {% assign _articles = site.categories[_category_id] %}
-      {%- include article-list.html
-            articles=_articles
-            type='grid'
-            size='md'
-            cover_type='background'
-            limit='6'
-            with_date='true'
-      -%}
-      <p>
-        <a href="/en/categories/{{ _category_id }}/">Read more...</a> ({{ site.categories[_category_id] | size }} articles)
-      </p>
-    </section>
-  </div>
-{%- endfor -%}
+{{ content }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,18 +33,24 @@ show_title: false
 <div class="layout--articles">
   <section class="my-5">
     {% assign _articles = site.categories["java-core"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
+    <p>
+      <a href="/en/categories/java-core/">Read more...</a> ({{ site.categories["java-core"] | size }} articles)
+    </p>
   </section>
 </div>
 
-<div class="article__content">
-  <h2>Java Testing</h2>
-</div>
 
 <div class="layout--articles">
+  <div class="article__content">
+    <h2>Java Testing</h2>
+  </div>
   <section class="my-5">
     {% assign _articles = site.categories["java-testing"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
+    <p>
+      <a href="/en/categories/java-testing/">Read more...</a> ({{ site.categories["java-testing"] | size }} articles)
+    </p>
   </section>
 </div>
 
@@ -55,6 +61,9 @@ show_title: false
 <div class="layout--articles">
   <section class="my-5">
     {% assign _articles = site.categories["java-rest"] %}
-    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
+    <p>
+      <a href="/en/categories/java-rest/">Read more...</a> ({{ site.categories["java-rest"] | size }} articles)
+    </p>
   </section>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,7 +40,14 @@ show_title: false
   <div class="layout--articles">
     <section class="my-5">
       {% assign _articles = site.categories[_category_id] %}
-      {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' limit='6' -%}
+      {%- include article-list.html
+            articles=_articles
+            type='grid'
+            size='md'
+            cover_type='background'
+            limit='6'
+            with_date='true'
+      -%}
       <p>
         <a href="/en/categories/{{ _category_id }}/">Read more...</a> ({{ site.categories[_category_id] | size }} articles)
       </p>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -51,7 +51,7 @@ Java Rest
 
 <div class="layout--articles">
   <section class="my-5">
-    {% assign _articles = site.categories["java-test"] %}
+    {% assign _articles = site.categories["java-rest"] %}
     {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
   </section>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,5 @@
 ---
-layout: articles
+layout: page
 titles:
   # @start locale config
   en      : &EN       Home
@@ -24,26 +24,43 @@ titles:
   fr-LU   : *FR
   # @end locale config
 show_title: false
-articles:
-  data_source: paginator.posts
-  article_type: BlogPosting
-  show_cover: true
-  cover_size: lg
-  show_excerpt: true
-  show_readmore: true
-  show_info: true
 ---
+
+articles:
+
+Java Core
 
 <div class="layout--articles">
   <section class="my-5">
-    {% assign _articles = site.categories[page.category] %}
+    {% assign _articles = site.categories["java-core"] %}
     {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
   </section>
 </div>
 
+Java Core
+
+<div class="layout--articles">
+  <section class="my-5">
+    {% assign _articles = site.categories["java-testing"] %}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+  </section>
+</div>
+
+
+Java Rest
+
+<div class="layout--articles">
+  <section class="my-5">
+    {% assign _articles = site.categories["java-test"] %}
+    {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
+  </section>
+</div>
+
+
+<!-- 
 <div class="layout--home">
   {%- include paginator.html paginate_pattern=page.paginate_pattern baseurl=page.baseurl -%}
-</div>
+</div> -->
 
 <script>
   {%- include scripts/home.js -%}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,10 +26,10 @@ titles:
 show_title: false
 ---
 
-articles:
-
-Java Core
-
+<div class="article__content">
+  <h2>Java Core</h2>
+</div>
+  
 <div class="layout--articles">
   <section class="my-5">
     {% assign _articles = site.categories["java-core"] %}
@@ -37,7 +37,9 @@ Java Core
   </section>
 </div>
 
-Java Core
+<div class="article__content">
+  <h2>Java Testing</h2>
+</div>
 
 <div class="layout--articles">
   <section class="my-5">
@@ -46,8 +48,9 @@ Java Core
   </section>
 </div>
 
-
-Java Rest
+<div class="article__content">
+  <h2>RESTful APIs</h2>
+</div>
 
 <div class="layout--articles">
   <section class="my-5">
@@ -55,15 +58,3 @@ Java Rest
     {%- include article-list.html articles=_articles type='grid' size='md' cover_type='background' -%}
   </section>
 </div>
-
-
-<!-- 
-<div class="layout--home">
-  {%- include paginator.html paginate_pattern=page.paginate_pattern baseurl=page.baseurl -%}
-</div> -->
-
-<script>
-  {%- include scripts/home.js -%}
-</script>
-
-{{ content }}

--- a/_posts/2021-01-31-juni5-parameterized-tests.md
+++ b/_posts/2021-01-31-juni5-parameterized-tests.md
@@ -3,7 +3,7 @@ layout:            post
 title:             Writing Parameterized Tests in JUnit 5
 lang:                en
 date:              2021-01-31 16:12:25 +0100
-categories:        [java-core]
+categories:        [java-testing]
 tags:              [java, junit, junit5, testing]
 permalink:         /2021/01/31/juni5-parameterized-tests/
 comments:          true

--- a/_sass/common/components/_card.scss
+++ b/_sass/common/components/_card.scss
@@ -118,4 +118,7 @@
     padding-top: 0;
     padding-left: 0;
   }
+  .card__content > p {
+    color: rgba(0, 0, 0, 0.54);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ baseurl: '/'
 ads_tags: [java, elasticsearch, devops, git, api, backend]
 ---
 
-{%- assign _highlighted_categories = 'temporal:Automation, elasticsearch:Elasticsearch, java-core:Java, java-testing:Testing, java-concurrency:Java Concurrency, java-rest:RESTful APIs, git:Git' | split: ', ' -%}
+{%- assign _highlighted_categories = 'temporal:Automation, elasticsearch:Elasticsearch, java-core:Java, java-testing:Testing, java-concurrency:Concurrency, java-rest:RESTful APIs, git:Git' | split: ', ' -%}
 
 {%- for _category in _highlighted_categories -%}
   {%- assign _kv = _category | split: ':' -%}
@@ -37,3 +37,15 @@ ads_tags: [java, elasticsearch, devops, git, api, backend]
     </section>
   </div>
 {%- endfor -%}
+
+
+<div class="article__content">
+  <h2>All Categories</h2>
+  <p>If you didn't find what you want in the highlighted categories above, here are more categories to discover :D</p>
+</div>
+
+<div class="layout--articles">
+  <section class="my-5">
+    {%- include article-list.html articles=site.displayed_en_categories type='grid' size='sm' cover_type='background' -%}
+  </section>
+</div>

--- a/index.html
+++ b/index.html
@@ -1,18 +1,39 @@
 ---
-layout: home
+layout: page
 title: Home
-pagination:
-  enabled: true
-  collection: posts
-  sort_field: date
-  sort_reverse: true
-  permalink: '/page:num/'
-
-# hack for "pagination.permalink"
-paginate_pattern: '/page:num/'
+show_title: false
 
 # hack for home path
 baseurl: '/'
 
 ads_tags: [java, elasticsearch, devops, git, api, backend]
 ---
+
+{%- assign _highlighted_categories = 'temporal:Automation, elasticsearch:Elasticsearch, java-core:Java, java-testing:Testing, java-concurrency:Java Concurrency, java-rest:RESTful APIs, git:Git' | split: ', ' -%}
+
+{%- for _category in _highlighted_categories -%}
+  {%- assign _kv = _category | split: ':' -%}
+  {%- assign _category_id = _kv.first -%}
+  {%- assign _category_title = _kv.last -%}
+
+  <div class="article__content">
+    <h2>{{ _category_title }}</h2>
+  </div>
+
+  <div class="layout--articles">
+    <section class="my-5">
+      {% assign _articles = site.categories[_category_id] %}
+      {%- include article-list.html
+            articles=_articles
+            type='grid'
+            size='md'
+            cover_type='background'
+            limit='6'
+            with_date='true'
+      -%}
+      <p>
+        <a href="/en/categories/{{ _category_id }}/">Read more...</a> ({{ site.categories[_category_id] | size }} articles)
+      </p>
+    </section>
+  </div>
+{%- endfor -%}

--- a/newpost.sh
+++ b/newpost.sh
@@ -103,7 +103,8 @@ tags:                []
 ads_tags:            []
 comments:            true
 excerpt:             >
-    TODO
+    Try to limit at 140 character, two lines: (80-4) *2 = 152
+
 image:               /assets/bg-coffee-84624_1280.jpg
 cover:               /assets/bg-coffee-84624_1280.jpg
 article_header:


### PR DESCRIPTION
This PR changes the home page layout so that the website can better highlight the structure of different categories. Prior to the PR, the home page is mainly focus on recent posts. This is inspired by <https://medium.com/javarevisited>

Before:

<img width="1440" alt="Screenshot 2022-10-01 at 17 20 50" src="https://user-images.githubusercontent.com/10179217/193416391-e91dc687-eb09-4346-b70f-9e16023c8e46.png">


After:

<img width="1440" alt="Screenshot 2022-10-01 at 17 21 30" src="https://user-images.githubusercontent.com/10179217/193416400-28d6d86d-48d8-45a2-81eb-e6c764cf1188.png">
