### PR TITLE
Fix `jekyll serve` on Ruby 3.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 # gem "github-pages", group: :jekyll_plugins
 gemspec
+
+# Pin logger < 1.6.0: Ruby 3.3.5 ships logger 1.6.0, whose Logger#level reads
+# @level_override, but Jekyll 4.3.1's Stevenson subclass overrides #initialize
+# without calling super, leaving @level_override nil and crashing `jekyll serve`.
+gem "logger", "~> 1.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,10 +77,11 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.5.3)
     mercenary (0.4.0)
     mini_portile2 (2.8.9)
     minitest (5.19.0)
@@ -113,6 +114,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   jekyll-text-theme!
+  logger (~> 1.5.3)
   rake (~> 12.3)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ gem install bundler
 # by this blog using bundler
 bundle install
 
-# run Jekyll
-jekyll serve
+# run Jekyll (use `bundle exec` so the versions
+# pinned in Gemfile.lock are used)
+bundle exec jekyll serve
 ```
 
 Or run via Docker:


### PR DESCRIPTION
## Summary

Local `bundle exec jekyll serve` was broken on Ruby 3.3.5 due to two incompatibilities between the current Ruby and Jekyll 4.3.1's locked gems. This unblocks running the blog locally without Docker.

## Fixes

- **`logger` crash at startup** — Ruby 3.3.5 ships `logger` 1.6.0, whose `Logger#level` reads `@level_override`. Jekyll's `Stevenson` logger subclass overrides `#initialize` without calling `super`, leaving `@level_override` nil → `undefined method '[]' for nil`. Pinned `logger` to `~> 1.5.3`.
- **`tainted?` crash during render** — Liquid 4.0.3 calls `String#tainted?`, which Ruby removed in 3.2 → `undefined method 'tainted?'`. Bumped Liquid to 4.0.4 (still within Jekyll's `~> 4.0` constraint), which dropped the taint checks.

## Testing

- `bundle install` succeeds
- `bundle exec jekyll serve` builds the site (~6s) and serves at http://localhost:4000/ (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)